### PR TITLE
fix/main-page-pagination-issue | 메인 페이지 상단 배너 오작동 문제

### DIFF
--- a/src/components/MainContent.js
+++ b/src/components/MainContent.js
@@ -220,14 +220,20 @@ const MainContent = ({ onMovieClick }) => {
             {/* 캐러셀 네비게이션 */}
             <button 
               className="carousel-nav carousel-prev" 
-              onClick={prevCarouselSlide}
+              onClick={(e) => {
+                e.stopPropagation();
+                prevCarouselSlide();
+              }}
               aria-label="이전 영화"
             >
               ‹
             </button>
             <button 
               className="carousel-nav carousel-next" 
-              onClick={nextCarouselSlide}
+              onClick={(e) => {
+                e.stopPropagation();
+                nextCarouselSlide();
+              }}
               aria-label="다음 영화"
             >
               ›
@@ -243,7 +249,10 @@ const MainContent = ({ onMovieClick }) => {
               <button
                 key={index}
                 className={`carousel-indicator ${index === currentCarouselIndex ? 'active' : ''}`}
-                onClick={() => setCurrentCarouselIndex(index)}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  setCurrentCarouselIndex(index);
+                }}
                 aria-label={`${index + 1}번째 영화로 이동`}
               />
             ))}


### PR DESCRIPTION
## 📌 관련 이슈

- #27 

## 🚩 주요 변경사항

- 페이지네이션 버튼들이 정상적으로 캐러셀 슬라이드만 제어하도록 수정

## 🛠️ 기술적 참고/특이사항

- 캐러셀 이전/다음 버튼 클릭 시 이벤트 버블링 방지 (각 버튼의 onClick 핸들러에서 e.stopPropagation() 추가)
- 캐러셀 인디케이터 버튼 클릭 시 이벤트 버블링 방지 (각 버튼의 onClick 핸들러에서 e.stopPropagation() 추가)
- 영향 범위: UI/UX 디자인이나 다른 기능에는 전혀 영향 없음, 오직 이벤트 처리 로직만 수정

## 👀 리뷰어에게 요청

- 다른 캐러셀 관련 기능들(자동 슬라이드, 키보드 네비게이션 등)이 정상 작동하는지 확인
- 향후 유사한 이벤트 버블링 문제가 발생할 수 있는 다른 컴포넌트가 있는지 점검

## 📋 후속 작업(To-Do)

- [ ] 다른 컴포넌트에서도 유사한 이벤트 버블링 문제가 있는지 전체 검토
- [ ] 캐러셀 관련 사용자 피드백 기반 UI/UX 개선

---

### 📝 기타

현재 메인 페이지 UI
<img width="1906" height="899" alt="image" src="https://github.com/user-attachments/assets/3dc0b07c-4282-43a9-902f-f4fde5292fc4" />

현재 메인 페이지 상단 배너 '다음 페이지' 버튼 클릭시
<img width="1896" height="896" alt="image" src="https://github.com/user-attachments/assets/ce734ae1-09a2-4389-80fb-05b6060d628b" />
