### PR TITLE
Fix/main page routing issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,9 +69,7 @@ npm start
 
 ### API 엔드포인트
 
-#### 인증 관련
-- `POST /api/auth/kakao` - 카카오 로그인
-- `POST /api/auth/refresh` - 토큰 갱신
+#### 사용자 관련
 - `GET /api/user/profile` - 사용자 프로필 조회
 
 #### 영화 관련 (새로 추가)

--- a/how --name-only a455221
+++ b/how --name-only a455221
@@ -1,0 +1,137 @@
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+import KakaoLogin from './KakaoLogin';
+import { useAuth } from '../hooks/useAuth';
+import './HomeScreen.css';
+
+const HomeScreen = ({ onStart }) => {
+  const { user, isAuthenticated, isLoading, error, login, logout, clearError } = useAuth();
+  const [loginError, setLoginError] = useState(null);
+
+  const handleLoginSuccess = async (data) => {
+    try {
+      clearError(); // useAuth 훅 에러 초기화
+      
+      // 백엔드로 로그인 요청
+      await login(data.kakaoAccessToken, data.userInfo);
+      if (process.env.MODE_ENV !== 'production') {
+        console.debug('백엔드 로그인 성공');
+      }
+    } catch (error) {
+      // useAuth.login 내부에서 이미 setError 처리됨
+      if (process.env.MODE_ENV !== 'production') {
+        console.error('백엔드 로그인 실패:', error);
+      }
+    }
+  };
+
+  const handleLoginError = (errorMessage) => {
+    setLoginError(errorMessage);
+  };
+
+  const handleLogout = () => {
+    logout();
+  };
+
+  const handleStartApp = () => {
+    if (isAuthenticated) {
+      onStart();
+    }
+  };
+
+  // 로딩 중일 때 표시
+  if (isLoading) {
+    return (
+      <div className="home-screen">
+        <div className="loading-container">
+          <div className="loading-spinner"></div>
+          <p>로딩 중...</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="home-screen">
+      <div className="home-content">
+        <div className="logo-section">
+          <img 
+            src="/MoodFlix (Logo).png" 
+            alt="MoodFlix Logo" 
+            className="home-logo"
+          />
+        </div>
+        
+        <div className="welcome-section">
+          <h1 className="welcome-title">MoodFlix에 오신 것을 환영합니다</h1>
+          <p className="welcome-subtitle">
+            당신의 기분에 맞는 완벽한 영화를 찾아보세요
+          </p>
+          <p className="welcome-description">
+            감정을 선택하고 기분을 설명하면, AI가 당신에게 딱 맞는 영화를 추천해드립니다.
+          </p>
+        </div>
+
+        {/* 에러 메시지 표시 */}
+        {(error || loginError) && (
+          <div className="error-message">
+            <p>{error || loginError}</p>
+            <button onClick={() => { setLoginError(null); clearError(); }}>닫기</button>
+          </div>
+        )}
+
+        {/* 로그인 상태에 따른 조건부 렌더링 */}
+        {!isAuthenticated ? (
+          <div className="login-section">
+            <KakaoLogin 
+              onLoginSuccess={handleLoginSuccess} 
+              onLoginError={handleLoginError}
+            />
+            <p className="login-description">
+              카카오 계정으로 간편하게 로그인하고 개인화된 영화 추천을 받아보세요
+            </p>
+          </div>
+        ) : (
+          <div className="user-section">
+            <div className="user-info">
+              <span className="user-welcome">안녕하세요, {user?.name || '사용자'}님!</span>
+              <button className="logout-button" onClick={handleLogout}>
+                로그아웃
+              </button>
+            </div>
+            <div className="action-section">
+              <button 
+                className="start-button"
+                onClick={handleStartApp}
+                aria-label="MoodFlix 시작하기"
+              >
+                시작하기
+              </button>
+            </div>
+          </div>
+        )}
+
+        <div className="features-section">
+          <div className="feature-item">
+            <span className="feature-icon">🎭</span>
+            <span className="feature-text">감정 기반 추천</span>
+          </div>
+          <div className="feature-item">
+            <span className="feature-icon">🎬</span>
+            <span className="feature-text">맞춤형 영화</span>
+          </div>
+          <div className="feature-item">
+            <span className="feature-icon">✨</span>
+            <span className="feature-text">AI 분석</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+HomeScreen.propTypes = {
+  onStart: PropTypes.func.isRequired,
+};
+
+export default HomeScreen;

--- a/public/index.html
+++ b/public/index.html
@@ -35,7 +35,17 @@
     <div id="root"></div>
     
     <!-- 카카오 SDK -->
-    <script src="https://developers.kakao.com/sdk/js/kakao.js"></script>
+    <script src="https://t1.kakaocdn.net/kakao_js_sdk/2.7.6/kakao.min.js" integrity="sha384-WAtVcQYcmTO/N+C1N+1m6Gp8qxh+3NlnP7X1U7qP6P5dQY/MsRBNTh+e1ahJrkEm" crossorigin="anonymous"></script>
+    <script>
+      // 카카오 SDK 로드 확인
+      window.addEventListener('load', function() {
+        if (window.Kakao) {
+          console.log('카카오 SDK 로드 완료');
+        } else {
+          console.error('카카오 SDK 로드 실패');
+        }
+      });
+    </script>
     
     <!--
       This HTML file is a template.

--- a/src/App.js
+++ b/src/App.js
@@ -43,7 +43,6 @@ function AppLayout() {
       />
       <Routes>
         <Route path="/" element={<MainContent onMovieClick={handleMovieClick} />} />
-        <Route path="/home" element={<MainContent onMovieClick={handleMovieClick} />} />
         <Route path="/search" element={<SearchModal isOpen={true} onClose={handleCloseSearch} onSearchResults={handleSearchResults} />} />
         <Route path="/recommendation" element={<MovieRecommendation onMovieClick={handleMovieClick} />} />
         <Route path="/calendar" element={<Calendar />} />

--- a/src/components/KakaoLogin.js
+++ b/src/components/KakaoLogin.js
@@ -105,9 +105,10 @@ const KakaoLogin = ({ onLoginSuccess, onLoginError, onKakaoCodeLogin }) => {
     setIsLoading(true);
 
     try {
-      // 카카오 로그인 페이지로 리다이렉트
+      // 카카오 로그인 페이지로 리다이렉트 (계정 선택 강제)
       window.Kakao.Auth.authorize({
-        redirectUri: window.location.origin
+        redirectUri: window.location.origin,
+        prompt: 'select_account' // 계정 선택 화면 강제 표시
       });
     } catch (error) {
       console.error('카카오 로그인 호출 중 오류:', error);

--- a/src/components/KakaoLogin.js
+++ b/src/components/KakaoLogin.js
@@ -1,63 +1,118 @@
 import React, { useEffect, useState } from 'react';
 import './KakaoLogin.css';
+import { checkKakaoAuthStatus, exchangeKakaoCodeForToken } from '../services/authService';
 
-const KakaoLogin = ({ onLoginSuccess, onLoginError }) => {
+const KakaoLogin = ({ onLoginSuccess, onLoginError, onKakaoCodeLogin }) => {
   const [isLoading, setIsLoading] = useState(false);
+  const [isInitialized, setIsInitialized] = useState(false);
+  const [processedCodes, setProcessedCodes] = useState(new Set());
 
   useEffect(() => {
     // 카카오 SDK 초기화
-    const kakaoKey = process.env.REACT_APP_KAKAO_JAVASCRIPT_KEY;
-    if (!kakaoKey) {
-      console.warn('REACT_APP_KAKAO_JAVASCRIPT_KEY가 설정되지 않았습니다.');
-      return;
-    }
-    if (window.Kakao && !window.Kakao.isInitialized()) {
-      window.Kakao.init(kakaoKey);
-    }
-  }, []);
-
-  const handleKakaoLogin = async () => {
-    if (!window.Kakao) {
-      onLoginError?.('카카오 SDK를 불러올 수 없습니다.');
-      return;
-    }
-
-    // 로그인 시점에 미초기화 시 재초기화 시도
-    if (!window.Kakao.isInitialized()) {
+    const initializeKakao = () => {
       const kakaoKey = process.env.REACT_APP_KAKAO_JAVASCRIPT_KEY;
       if (!kakaoKey) {
-        onLoginError?.('카카오 설정 누락으로 로그인을 진행할 수 없습니다.');
+        console.warn('카카오 JavaScript 키가 설정되지 않았습니다.');
         return;
       }
-      try {
-        window.Kakao.init(kakaoKey);
-      } catch (e) {
-        console.error('카카오 SDK 초기화 실패:', e);
-        onLoginError?.('카카오 설정 오류로 로그인을 진행할 수 없습니다.');
+
+      if (window.Kakao && typeof window.Kakao.init === 'function') {
+        if (!window.Kakao.isInitialized()) {
+          try {
+            window.Kakao.init(kakaoKey);
+            console.log('카카오 SDK 초기화 완료');
+          } catch (error) {
+            console.error('카카오 SDK 초기화 실패:', error);
+            return;
+          }
+        }
+        setIsInitialized(true);
+      } else {
+        // SDK 로드 대기
+        setTimeout(initializeKakao, 1000);
+      }
+    };
+
+    // URL 파라미터 확인
+    const checkUrlParams = () => {
+      const urlParams = new URLSearchParams(window.location.search);
+      const code = urlParams.get('code');
+      const error = urlParams.get('error');
+
+      if (error) {
+        console.error('카카오 로그인 에러:', error);
+        onLoginError?.('카카오 로그인에 실패했습니다.');
         return;
       }
+
+      if (code && !processedCodes.has(code)) {
+        console.log('카카오 인증 코드 받음');
+        // URL에서 인가 코드 즉시 제거 (중복 실행 방지)
+        window.history.replaceState({}, document.title, window.location.pathname);
+        handleCodeExchange(code);
+        return;
+      }
+    };
+
+    // 초기화 및 URL 파라미터 확인
+    initializeKakao();
+    checkUrlParams();
+  }, []);
+
+  // 카카오 인가 코드 처리
+  const handleCodeExchange = async (code) => {
+    if (isLoading || processedCodes.has(code)) {
+      console.log('이미 처리 중이거나 처리된 코드입니다.');
+      return;
     }
 
     try {
       setIsLoading(true);
-      
-      const authObj = await new Promise((resolve, reject) => {
-        window.Kakao.Auth.login({
-          success: resolve,
-          fail: reject,
-        });
-      });
-      
-      // console.debug('카카오 로그인 성공'); // 필요 시 개발 환경에서만
+      setProcessedCodes(prev => new Set(prev).add(code));
+      console.log('카카오 인가 코드를 토큰으로 변환 중...');
 
-      // ✅ [핵심 수정] 성공 시, 백엔드 통신 없이 액세스 토큰만 부모 컴포넌트에게 전달합니다.
-      onLoginSuccess?.(authObj.access_token);
+      const tokenData = await exchangeKakaoCodeForToken(code);
 
+      if (tokenData && tokenData.accessToken) {
+        console.log('카카오 토큰 교환 성공');
+        onLoginSuccess?.(tokenData.accessToken);
+      } else {
+        console.log('토큰 교환 실패, 인가 코드를 상위 컴포넌트로 전달');
+        onKakaoCodeLogin?.(code);
+      }
     } catch (error) {
-      console.error('카카오 SDK 로그인 실패:', error);
-      onLoginError?.('카카오 로그인에 실패했습니다.');
+      console.error('카카오 토큰 교환 실패:', error);
+      onLoginError?.('카카오 로그인 처리 중 오류가 발생했습니다.');
     } finally {
       setIsLoading(false);
+    }
+  };
+
+  // 카카오 로그인 버튼 클릭
+  const handleKakaoLogin = () => {
+    if (!isInitialized) {
+      console.error('카카오 SDK가 초기화되지 않았습니다.');
+      onLoginError?.('카카오 SDK를 불러올 수 없습니다.');
+      return;
+    }
+
+    if (!window.Kakao.Auth) {
+      console.error('카카오 Auth 객체가 존재하지 않습니다.');
+      onLoginError?.('카카오 인증 서비스를 사용할 수 없습니다.');
+      return;
+    }
+
+    setIsLoading(true);
+
+    try {
+      // 카카오 로그인 페이지로 리다이렉트
+      window.Kakao.Auth.authorize({
+        redirectUri: window.location.origin
+      });
+    } catch (error) {
+      console.error('카카오 로그인 호출 중 오류:', error);
+      setIsLoading(false);
+      onLoginError?.('카카오 로그인 중 오류가 발생했습니다.');
     }
   };
 

--- a/src/components/MainContent.js
+++ b/src/components/MainContent.js
@@ -15,9 +15,9 @@ const MainContent = ({ onMovieClick }) => {
   } = useMovies();
 
   // 인증 관련 상태
-  const { user, isAuthenticated, isLoading: authLoading, error: authError, login, logout, clearError } = useAuth();
+  const { user, isAuthenticated, isLoading: authLoading, error: authError, login, loginWithKakaoCode, logout, clearError } = useAuth();
 
-  // 로그인 핸들러
+  // 로그인 핸들러 (카카오 액세스 토큰)
   const handleLoginSuccess = async (kakaoAccessToken) => {
     try {
       clearError();
@@ -25,6 +25,17 @@ const MainContent = ({ onMovieClick }) => {
       console.log('MainContent: 로그인 성공');
     } catch (err) {
       console.error('MainContent: 로그인 실패', err);
+    }
+  };
+
+  // 카카오 인가 코드로 로그인 핸들러
+  const handleKakaoCodeLogin = async (authorizationCode) => {
+    try {
+      clearError();
+      await loginWithKakaoCode(authorizationCode);
+      console.log('MainContent: 카카오 코드 로그인 성공');
+    } catch (err) {
+      console.error('MainContent: 카카오 코드 로그인 실패', err);
     }
   };
 
@@ -181,6 +192,7 @@ const MainContent = ({ onMovieClick }) => {
             <KakaoLogin 
               onLoginSuccess={handleLoginSuccess} 
               onLoginError={handleLoginError}
+              onKakaoCodeLogin={handleKakaoCodeLogin}
             />
             {authError && (
               <div className="compact-auth-error">

--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -17,7 +17,7 @@ const Sidebar = ({ onNavigation }) => {
 
   const isActive = (path) => {
     if (path === '/') {
-      return location.pathname === '/home' || location.pathname === '/';
+      return location.pathname === '/' || location.pathname === '/';
     }
     if (path === '/search') {
       return location.pathname === '/search';

--- a/src/constants/api.js
+++ b/src/constants/api.js
@@ -6,11 +6,6 @@ export const API_BASE_URL =
 
 // API 엔드포인트
 export const API_ENDPOINTS = {
-  // 인증 관련
-  KAKAO_LOGIN: '/api/auth/kakao',
-  KAKAO_CALLBACK: '/api/auth/kakao/callback',
-  REFRESH_TOKEN: '/api/auth/refresh',
-  
   // 사용자 관련
   USER_PROFILE: '/api/user/profile',
   USER_PREFERENCES: '/api/user/preferences',

--- a/src/services/authService.js
+++ b/src/services/authService.js
@@ -1,111 +1,206 @@
-import axios from 'axios';
-import { jwtDecode } from "jwt-decode";
-import { API_BASE_URL } from '../constants/api';
+/**
+ * 카카오 인증 서비스
+ * 간단하고 명확한 로직으로 재작성
+ */
 
-// API 기본 URL은 constants에서 단일 관리합니다.
-
-const authApi = axios.create({
-  baseURL: API_BASE_URL,
-  timeout: 10000,
-});
-
-// 요청 인터셉터 - 모든 요청에 인증 헤더를 자동으로 추가합니다.
-authApi.interceptors.request.use(
-  (config) => {
-    const accessToken = localStorage.getItem('accessToken');
-    if (accessToken) {
-      config.headers.Authorization = `Bearer ${accessToken}`;
-    }
-    return config;
-  },
-  (error) => Promise.reject(error)
-);
+// 전역 처리 상태 (중복 방지)
+let isProcessing = false;
+const processedCodes = new Set();
 
 /**
- * 카카오 로그인 서비스 로직
- * KakaoLogin.js에서 받은 카카오 액세스 토큰으로 백엔드에 로그인/회원가입을 요청합니다.
- * @param {string} kakaoAccessToken - 카카오 SDK로부터 받은 액세스 토큰
- * @returns {object} - 백엔드로부터 받은 { accessToken, userId, name } 데이터
+ * 카카오 인가 코드를 액세스 토큰으로 변환
+ */
+export const exchangeKakaoCodeForToken = async (authorizationCode) => {
+  // 이미 처리된 코드인지 확인
+  if (processedCodes.has(authorizationCode)) {
+    console.log('이미 처리된 인가 코드입니다.');
+    return null;
+  }
+
+  // 현재 처리 중인지 확인
+  if (isProcessing) {
+    console.log('다른 요청이 처리 중입니다. 잠시 후 다시 시도해주세요.');
+    return null;
+  }
+
+  isProcessing = true;
+  processedCodes.add(authorizationCode);
+
+  try {
+    console.log('카카오 토큰 교환 시작');
+    
+    const kakaoAppKey = process.env.REACT_APP_KAKAO_APP_KEY || process.env.REACT_APP_KAKAO_JAVASCRIPT_KEY;
+    if (!kakaoAppKey) {
+      throw new Error('카카오 앱 키가 설정되지 않았습니다.');
+    }
+
+    // 카카오 OAuth API 호출
+    const tokenResponse = await fetch('https://kauth.kakao.com/oauth/token', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded'
+      },
+      body: new URLSearchParams({
+        grant_type: 'authorization_code',
+        client_id: kakaoAppKey,
+        redirect_uri: window.location.origin,
+        code: authorizationCode
+      })
+    });
+
+    if (!tokenResponse.ok) {
+      const errorData = await tokenResponse.json();
+      throw new Error(`토큰 요청 실패: ${errorData.error_description || errorData.error}`);
+    }
+
+    const tokenData = await tokenResponse.json();
+    console.log('카카오 토큰 획득 성공');
+
+    // 사용자 정보 조회
+    const userResponse = await fetch('https://kapi.kakao.com/v2/user/me', {
+      headers: {
+        'Authorization': `Bearer ${tokenData.access_token}`
+      }
+    });
+
+    if (!userResponse.ok) {
+      throw new Error('사용자 정보 조회 실패');
+    }
+
+    const userData = await userResponse.json();
+    console.log('카카오 사용자 정보 조회 성공');
+
+    return {
+      accessToken: tokenData.access_token,
+      refreshToken: tokenData.refresh_token,
+      userInfo: {
+        id: userData.id,
+        name: userData.kakao_account?.profile?.nickname || '카카오 사용자',
+        email: userData.kakao_account?.email,
+        profileImage: userData.kakao_account?.profile?.profile_image_url
+      }
+    };
+
+  } catch (error) {
+    console.error('카카오 토큰 교환 실패:', error);
+    throw error;
+  } finally {
+    isProcessing = false;
+  }
+};
+
+/**
+ * 카카오 로그인 처리
  */
 export const kakaoLogin = async (kakaoAccessToken) => {
   try {
-    const response = await authApi.post('/api/auth/kakao', {
-      accessToken: kakaoAccessToken,
-    });
+    console.log('카카오 로그인 처리 시작');
     
-    const data = response.data;
-    
-    // 백엔드로부터 받은 JWT와 사용자 정보를 로컬 스토리지에 저장합니다.
-    if (data && data.accessToken) {
-      localStorage.setItem('accessToken', data.accessToken);
-      if (data.refreshToken) {
-        localStorage.setItem('refreshToken', data.refreshToken);
+    // 사용자 정보 조회
+    const userResponse = await fetch('https://kapi.kakao.com/v2/user/me', {
+      headers: {
+        'Authorization': `Bearer ${kakaoAccessToken}`
       }
-      const user = data.user ?? { userId: data.userId, name: data.name, email: data.email, profileImage: data.profileImage };
-      localStorage.setItem('userInfo', JSON.stringify(user));
+    });
+
+    if (!userResponse.ok) {
+      throw new Error('사용자 정보 조회 실패');
     }
-    
-    return data;
+
+    const userData = await userResponse.json();
+    console.log('카카오 사용자 정보 조회 성공');
+
+    // 사용자 정보 정규화
+    const userInfo = {
+      id: userData.id,
+      name: userData.kakao_account?.profile?.nickname || '카카오 사용자',
+      email: userData.kakao_account?.email,
+      profileImage: userData.kakao_account?.profile?.profile_image_url
+    };
+
+    // 로컬 스토리지에 저장
+    localStorage.setItem('accessToken', kakaoAccessToken);
+    localStorage.setItem('userInfo', JSON.stringify(userInfo));
+
+    return {
+      accessToken: kakaoAccessToken,
+      user: userInfo
+    };
+
   } catch (error) {
-    console.error('카카오 로그인 API 호출 실패:', error.response?.status, error.message);
+    console.error('카카오 로그인 실패:', error);
     throw error;
   }
 };
 
-// [참고] 토큰 갱신 로직 (백엔드에 /api/auth/refresh API 구현 후 사용 가능)
-export const refreshToken = async () => {
-  const stored = localStorage.getItem('refreshToken');
-  if (!stored) {
-    throw new Error('리프레시 토큰이 없습니다.');
-  }
-  try {
-    const res = await authApi.post('/api/auth/refresh', { refreshToken: stored }, { withCredentials: true });
-    const data = res.data;
-    if (data?.accessToken) {
-      localStorage.setItem('accessToken', data.accessToken);
-    }
-    if (data?.refreshToken) {
-      localStorage.setItem('refreshToken', data.refreshToken);
-    }
-    if (data?.user) {
-      localStorage.setItem('userInfo', JSON.stringify(data.user));
-    }
-    return data;
-  } catch (error) {
-    localStorage.removeItem('accessToken');
-    localStorage.removeItem('refreshToken');
-    localStorage.removeItem('userInfo');
-    throw error;
-  }
-};
-
-// 로그아웃
+/**
+ * 로그아웃
+ */
 export const logout = () => {
+  console.log('로그아웃 처리');
+  
+  // 로컬 스토리지 정리
   localStorage.removeItem('accessToken');
   localStorage.removeItem('refreshToken');
   localStorage.removeItem('userInfo');
   
-  if (window.Kakao && window.Kakao.Auth && window.Kakao.Auth.getAccessToken()) {
-    window.Kakao.Auth.logout();
+  // 카카오 SDK 토큰만 정리 (서버 요청 없이)
+  if (window.Kakao && window.Kakao.Auth) {
+    try {
+      // 서버에 요청을 보내지 않고 로컬 토큰만 정리
+      window.Kakao.Auth.setAccessToken(null);
+    } catch (error) {
+      console.error('카카오 토큰 정리 실패:', error);
+    }
   }
 };
 
-// 토큰 유효성 검사
+/**
+ * 토큰 유효성 검사
+ */
 export const isTokenValid = () => {
   const token = localStorage.getItem('accessToken');
-  if (!token) return false;
-  
-  try {
-    const { exp } = jwtDecode(token);
-    const currentTime = Math.floor(Date.now() / 1000);
-    return typeof exp === 'number' && exp > currentTime;
-  } catch (error) {
-    return false;
-  }
+  return !!token;
 };
 
-//  [수정] 저장된 사용자 정보 가져오기 (함수 이름을 원래대로 되돌림)
+/**
+ * 저장된 사용자 정보 가져오기
+ */
 export const getUserProfile = () => {
-    const userInfo = localStorage.getItem('userInfo');
-    return userInfo ? JSON.parse(userInfo) : null;
+  const userInfo = localStorage.getItem('userInfo');
+  return userInfo ? JSON.parse(userInfo) : null;
+};
+
+/**
+ * 카카오 인증 상태 확인
+ */
+export const checkKakaoAuthStatus = async () => {
+  if (!window.Kakao || !window.Kakao.Auth) {
+    return { isConnected: false, token: null };
+  }
+
+  try {
+    const token = window.Kakao.Auth.getAccessToken();
+    if (!token) {
+      return { isConnected: false, token: null };
+    }
+
+    return new Promise((resolve) => {
+      window.Kakao.Auth.getStatusInfo({
+        success: (response) => {
+          resolve({
+            isConnected: response.status === 'connected',
+            token: token,
+            userInfo: response.user
+          });
+        },
+        fail: () => {
+          resolve({ isConnected: false, token: null });
+        }
+      });
+    });
+  } catch (error) {
+    console.error('카카오 토큰 상태 확인 실패:', error);
+    return { isConnected: false, token: null };
+  }
 };


### PR DESCRIPTION
## 📌 관련 이슈

- #34 

## 🚩 주요 변경사항

- 구버전 페이지 로드 문제 해결 (브라우저 캐시 무효화 및 Service Worker 업데이트)
- Service Worker 캐시 버전 관리 개선 (public/sw.js - CACHE_NAME 버전 업데이트)
- 카카오 로그아웃 시 원래 계정으로 자동 재로그인되는 버그 수정
- 로그아웃 시 카카오 SDK 세션 완전 정리 기능 추가 (clearKakaoSession 함수)
- 카카오 로그인 시 계정 선택 화면 강제 표시 (prompt: 'select_account' 옵션 추가)
- 카카오 로그아웃 API 401 에러 처리 개선 (토큰 유효성 사전 확인)
- 로그아웃 시 서버 요청 실패와 관계없이 로컬 세션 안전하게 정리

## 🛠️ 기술적 참고/특이사항

- Service Worker 캐시 관리: CACHE_NAME 버전 업데이트로 구버전 캐시 무효화
- 브라우저 캐시 문제 해결: Service Worker의 skipWaiting() 및 clients.claim() 사용으로 즉시 업데이트 적용
- 로그아웃 시 카카오 SDK 세션 완전 정리 기능 추가 (clearKakaoSession 함수)
- 카카오 로그인 시 계정 선택 화면 강제 표시 (prompt: 'select_account' 옵션 추가)
- 토큰 유효성 검사: 로그아웃 전 토큰 존재 여부를 확인하여 불필요한 API 호출 방지
- 로그아웃 시 서버 요청 실패와 관계없이 로컬 세션 안전하게 정리

## 👀 리뷰어에게 요청

- 카카오 SDK 세션 정리 로직: clearKakaoSession 함수의 구현이 적절한지 검토
- 에러 처리 방식: 서버 요청 실패 시 로컬 정리만 수행하는 방식이 올바른지 검토
- 보안 측면: 로그아웃 시 세션 정리가 완전히 이루어지는지 보안 관점에서 검토
- Service Worker 캐시 전략: 구버전 캐시 무효화 방식이 적절한지 검토

## 📋 후속 작업(To-Do)

- [ ] 구버전 캐시 문제 재발 방지를 위한 캐시 무효화 전략 개선
- [ ] 다른 브라우저에서도 동일하게 작동하는지 확인
- [ ] 로그아웃 후 재로그인 시 계정 선택이 정상적으로 작동하는지 테스트
- [ ] 로그아웃 관련 사용자 피드백 수집 및 개선

---

### 📝 기타

현재 메인 페이지 UI (로그인 전)
<img width="1908" height="899" alt="image" src="https://github.com/user-attachments/assets/b8608ed6-5e4e-4798-a942-3272458ef2a0" />

카카오 로그인 페이지
<img width="1910" height="896" alt="image" src="https://github.com/user-attachments/assets/71c72a37-3bc1-44a4-8cd4-6df46965b00c" />

현재 메인 페이지 UI (로그인 후)
<img width="1904" height="901" alt="image" src="https://github.com/user-attachments/assets/8afe18e3-a938-4269-87f6-141e6b504494" />
